### PR TITLE
QoL Updates to orthologs and config

### DIFF
--- a/chapters/05-lincs.Rmd
+++ b/chapters/05-lincs.Rmd
@@ -14,16 +14,30 @@ global_state$data <- global_state$data %>%
     signature <- x$data
     
     # If we don't have human datam, convert mouse or rat genes to human orthologs for iLINCS
-    if(global_state$species != "human") { 
-      orthologs <- babelgene::orthologs(genes = signature$Symbol, 
+    if(global_state$species != "human") {
+      org.db = switch (global_state$species,,
+        "mouse" = org.Mm.eg.db::org.Mm.eg.db,
+        "rat" = org.Rn.eg.db::org.Rn.eg.db
+      )
+      
+      remapped_genes <- AnnotationDbi::select(org.db, 
+        keys = signature$Symbol, 
+        columns = c("SYMBOL", "ALIAS"), 
+        keytype = "ALIAS") %>%
+        dplyr::rename(Original_Symbol = ALIAS, MGI_Symbol = SYMBOL)
+      
+      
+      orthologs <- babelgene::orthologs(genes = remapped_genes$MGI_Symbol, 
                                         human = FALSE, 
                                         species = global_state$species) %>%
-        dplyr::select(Symbol = human_symbol, Symbol_old = symbol)
+        dplyr::select(HGNC_Symbol = human_symbol, MGI_Symbol = symbol) %>%
+        dplyr::inner_join(remapped_genes, 
+                          by = "MGI_Symbol")
       
       signature <- signature %>%
-        dplyr::rename(Symbol_old = Symbol) %>%
-        dplyr::inner_join(orthologs, by = "Symbol_old") %>%
-        dplyr::select(-Symbol_old)
+        dplyr::rename(Original_Symbol = Symbol) %>%
+        dplyr::inner_join(orthologs, by = "Original_Symbol") %>%
+        dplyr::select(Symbol = HGNC_Symbol, log2FoldChange, pvalue)
     }
     
     # Run iLINCS on our signature

--- a/configuration.yml
+++ b/configuration.yml
@@ -8,8 +8,8 @@ data:
   - group1: Disease B
     group2: Control B
     file: DBvsCB.csv
-design: design.csv
-counts: counts.csv
+# design: design.csv
+# counts: counts.csv
 
 # Debugging
 save_environment: false # Save whole environment or just global state?


### PR DESCRIPTION
Signed-off-by: Ali Sajid Imami <395482+AliSajid@users.noreply.github.com>

# Pull Request

## Description

This pull request includes changes to improve gene ortholog mapping and update the configuration file. The most important changes involve refining the process for converting non-human genes to human orthologs and commenting out unused configuration fields.

### Gene ortholog mapping improvements:
* [`chapters/05-lincs.Rmd`](diffhunk://#diff-781b03ff5bc98db01f65c48a16eab555998b1d14bd275fc06e262a52550d5f3bL18-R40): Enhanced the process for mapping non-human genes to human orthologs by introducing the use of `AnnotationDbi` and species-specific databases (`org.Mm.eg.db` for mouse and `org.Rn.eg.db` for rat). This ensures more accurate gene mapping and includes additional fields like `Original_Symbol` and `MGI_Symbol` for better traceability.

### Configuration updates:
* [`configuration.yml`](diffhunk://#diff-076cb2d0c23fedf9e506a0465551e1ad7409907323037b0043e22434e278bb39L11-R12): Commented out the `design` and `counts` fields, indicating they are not currently in use. This helps streamline the configuration file and reduce confusion.

## Checklist

- [X] I have tested these changes locally
- [X] I have updated relevant documentation
- [X] I have added/updated tests if applicable
- [X] All tests pass successfully
- [X] I have reviewed my code changes
- [X] I have addressed any feedback from code reviews