### PR TITLE
Added Average Similarity per MOA to MOA counts table in iLINCS results section

### DIFF
--- a/R/format_moa_results.R
+++ b/R/format_moa_results.R
@@ -1,6 +1,6 @@
 #Input: Annotated DrugFindr investigate signature results
 format_moa_results <- function(df) {
   df %>%
-    dplyr::select(MOA = integratedMoas, N)
+    dplyr::select(MOA = integratedMoas, N, AvgSimilarity)
   
 }

--- a/R/generate_moa_report.R
+++ b/R/generate_moa_report.R
@@ -1,7 +1,7 @@
 #Input: Annotated DrugFindr investigate signature results
 generate_moa_report <- function(annotated_signature) {
   moa_report <- annotated_signature %>%
-    dplyr::select(integratedMoas, Target, GeneTargets) %>%
+    dplyr::select(integratedMoas, Target, GeneTargets, Similarity) %>%
     dplyr::filter(integratedMoas != "" & !is.na(integratedMoas)) %>%
     tidyr::separate_rows(integratedMoas, sep = "\\|") %>%
     tidyr::separate_rows(GeneTargets, sep = "\\|") %>%
@@ -10,7 +10,8 @@ generate_moa_report <- function(annotated_signature) {
     dplyr::summarise(
       Target = paste(unique(Target), collapse = "|"),
       GeneTargets = paste(unique(GeneTargets), collapse = "|"),
-      N = dplyr::n()
+      N = dplyr::n(),
+      AvgSimilarity = mean(Similarity, na.rm = TRUE)
     ) %>%
     dplyr::arrange(dplyr::desc(N))
     


### PR DESCRIPTION
# Pull Request

## Description

This change adds a column to the MOA counts table that contains the average similarity for each MOA, to inform which MOA's have high average similarity scores in addition to high numbers of identified MOA's.

<img width="1318" height="1024" alt="image" src="https://github.com/user-attachments/assets/59c7a62d-b7cb-466d-8725-8fcf759a2638" />
